### PR TITLE
add supersample option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,9 @@ Ehm, the default black one does not look that good in this case. Let's try some 
    :align: center
    :scale: 50%
 
+Note that the edges of the hexagon look a little jagged. You can apply supersampling to render smooth edges using the ``--supersample`` option. This option takes a number specifying the scale factor to use. This works by internally rendering the sticker at a higher resolution, then scaling it back down before saving the result.
+For example, if you pass ``--supersample 2``, the sticker will internally be rendered at twice the size, ``--supersample 4`` would be four times the size, and so on. Greater values result in a somewhat smoother result, at the expense of higher memory usage. This effect has diminishing returns; usually a value of 2 is enough for a nice result and going higher than 4 does not make much noticeable improvement.
+
 As you can see, this tool can automate creation of hexagon stickers so they respect the hexagon standard. Feel free to additionally adjust the resulting image of your logo or the input image.
 
 This tool supports only raster graphics.

--- a/README.rst
+++ b/README.rst
@@ -104,8 +104,7 @@ Ehm, the default black one does not look that good in this case. Let's try some 
    :align: center
    :scale: 50%
 
-Note that the edges of the hexagon look a little jagged. You can apply supersampling to render smooth edges using the ``--supersample`` option. This option takes a number specifying the scale factor to use. This works by internally rendering the sticker at a higher resolution, then scaling it back down before saving the result.
-For example, if you pass ``--supersample 2``, the sticker will internally be rendered at twice the size, ``--supersample 4`` would be four times the size, and so on. Greater values result in a somewhat smoother result, at the expense of higher memory usage. This effect has diminishing returns; usually a value of 2 is enough for a nice result and going higher than 4 does not make much noticeable improvement.
+Note that the edges of the hexagon look a little jagged. You can add ``--supersample 2`` to the previous command to remedy this. The number given sets the scale factor to use. Greater values result in a smoother result, at the expense of higher memory usage. This effect has diminishing returns; usually a value of 2 is enough for a nice result and going higher than 4 does not make much noticeable improvement.
 
 As you can see, this tool can automate creation of hexagon stickers so they respect the hexagon standard. Feel free to additionally adjust the resulting image of your logo or the input image.
 

--- a/hexsticker/cli.py
+++ b/hexsticker/cli.py
@@ -12,6 +12,7 @@ from hexsticker.create import create_hexsticker
 from hexsticker.create import DEFAULT_BACKGROUND_COLOR
 from hexsticker.create import DEFAULT_BORDER_COLOR
 from hexsticker.create import DEFAULT_PADDING_COLOR
+from hexsticker.create import DEFAULT_SUPERSAMPLE
 
 logging.basicConfig()
 _LOGGER = logging.getLogger(hexsticker_name)
@@ -42,6 +43,8 @@ def _print_version(ctx, _, value):
 @click.option('--background-color', default=None, show_default=True, type=str,
               help=f"Background color for surrounding hexagon. "
                    f"Defaults to {DEFAULT_BACKGROUND_COLOR} if not provided.")
+@click.option('--supersample', default=DEFAULT_SUPERSAMPLE, show_default=True, type=int,
+              help=f"Scale factor to use for supersampling.")
 @click.option('--version', is_flag=True, is_eager=True, callback=_print_version, expose_value=False,
               help=f"Print {hexsticker_name} version and exit.")
 @click.option('--verbose', '-v', is_flag=True,
@@ -49,6 +52,7 @@ def _print_version(ctx, _, value):
 def hexsticker(image, output,
                border_size=0, border_color=None, padding_size=0,
                padding_color=None, background_color=None,
+               supersample=DEFAULT_SUPERSAMPLE,
                verbose=False):
     """Convert an image to hexagon sticker as defined by the Stickers Standard.
 


### PR DESCRIPTION
I added a `--supersample N` option to allow for a smoother output image. By upscaling the image before rendering the hexagon, then downscaling again before writing the output, we can get nice smooth hexagon edges.

Let me know if this is something you're interested in.