### PR TITLE
Mention hexsticker AUR package in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,17 @@ After the installation step listed above, you will be able to use the `hexsticke
 
   $ hexsticker --help
 
+Arch Linux
+^^^^^^^^^^
+
+There is an AUR package available here: https://aur.archlinux.org/packages/hexsticker
+
+For example with ``yay`` you can install it like this:
+
+.. code-block:: console
+
+  $ yay -S hexsticker
+
 
 Requirements
 ============


### PR DESCRIPTION
I'm not sure if it's better in this section about installation or if I should add it to the bottom of the page by where the "Running from repo" text is now. Also this is the only link in the document so far that shows the URL, I think this is fine, but if you find it ugly maybe I could rephrase the text so that "AUR package available" is the link and no URL is visible.